### PR TITLE
Most method receivers should not take pointers

### DIFF
--- a/date.go
+++ b/date.go
@@ -37,8 +37,8 @@ func (d *Date) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON marshals a Date into JSON format. The date is formatted
 // in RFC 3339 full-date format -- that is, yyyy-mm-dd.
-func (d *Date) MarshalJSON() ([]byte, error) {
-	t := time.Time(*d)
+func (d Date) MarshalJSON() ([]byte, error) {
+	t := time.Time(d)
 	ds := "\"" + t.Format(dateFormat) + "\""
 	return []byte(ds), nil
 }
@@ -46,15 +46,15 @@ func (d *Date) MarshalJSON() ([]byte, error) {
 // Implement Stringer
 
 // String returns the value of the Date in ISO-8601 / RFC 3339 format yyyy-mm-dd.
-func (d *Date) String() string {
-	return time.Time(*d).Format(dateFormat)
+func (d Date) String() string {
+	return time.Time(d).Format(dateFormat)
 }
 
 // Implement Valuer
 
 // Value implements the database/sql Valuer interface.
-func (d *Date) Value() (driver.Value, error) {
-	return time.Time(*d), nil
+func (d Date) Value() (driver.Value, error) {
+	return time.Time(d), nil
 }
 
 // Implement Scanner
@@ -73,21 +73,21 @@ func (d *Date) Scan(value interface{}) error {
 }
 
 // Before returns true if the first date (the reciever) is before the second date (the argument).
-func (d *Date) Before(other Date) bool {
-	return time.Time(*d).Before(time.Time(other))
+func (d Date) Before(other Date) bool {
+	return time.Time(d).Before(time.Time(other))
 }
 
 // After returns true if the first date (the reciever) is after the second date (the argument).
-func (d *Date) After(other Date) bool {
-	return time.Time(*d).After(time.Time(other))
+func (d Date) After(other Date) bool {
+	return time.Time(d).After(time.Time(other))
 }
 
 // Equal returns true if the two dates are equal.
-func (d *Date) Equal(other Date) bool {
-	return time.Time(*d).Equal(time.Time(other))
+func (d Date) Equal(other Date) bool {
+	return time.Time(d).Equal(time.Time(other))
 }
 
 // AddDate adds the specified number of years, months and days to the Date, returning another Date.
-func (d *Date) AddDate(yy int, mm int, dd int) Date {
-	return Date(time.Time(*d).AddDate(yy, mm, dd))
+func (d Date) AddDate(yy int, mm int, dd int) Date {
+	return Date(time.Time(d).AddDate(yy, mm, dd))
 }

--- a/nulldate.go
+++ b/nulldate.go
@@ -8,14 +8,14 @@ import (
 )
 
 type NullDate struct {
-	Date Date
+	Date  Date
 	Valid bool
 }
 
 // NewNullDate constructs a new NullDate object for the given year, month and day
 func NewNullDate(y, m, d int) NullDate {
 	return NullDate{
-		Date: NewDate(y, m, d),
+		Date:  NewDate(y, m, d),
 		Valid: true,
 	}
 }
@@ -38,7 +38,7 @@ func (d *NullDate) UnmarshalJSON(b []byte) error {
 	}
 	t, err := time.Parse(dateFormat, sd)
 	*d = NullDate{
-		Date: Date(t),
+		Date:  Date(t),
 		Valid: true,
 	}
 	return err
@@ -46,7 +46,7 @@ func (d *NullDate) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON marshals a NullDate into JSON format. The date is formatted
 // in RFC 3339 full-date format -- that is, yyyy-mm-dd.
-func (d *NullDate) MarshalJSON() ([]byte, error) {
+func (d NullDate) MarshalJSON() ([]byte, error) {
 	var ds string
 	if d.Valid {
 		t := time.Time(d.Date)
@@ -60,7 +60,7 @@ func (d *NullDate) MarshalJSON() ([]byte, error) {
 // Implement Stringer
 
 // String returns the value of the NullDate in ISO-8601 / RFC 3339 format yyyy-mm-dd.
-func (d *NullDate) String() string {
+func (d NullDate) String() string {
 	if d.Valid {
 		return d.Date.String()
 	}
@@ -70,7 +70,7 @@ func (d *NullDate) String() string {
 // Implement Valuer
 
 // Value implements the database/sql Valuer interface.
-func (d *NullDate) Value() (driver.Value, error) {
+func (d NullDate) Value() (driver.Value, error) {
 	if d.Valid {
 		return time.Time(d.Date), nil
 	}
@@ -95,7 +95,7 @@ func (d *NullDate) Scan(value interface{}) error {
 }
 
 // Equal returns true if the two dates are equal.
-func (d *NullDate) Equal(other NullDate) bool {
+func (d NullDate) Equal(other NullDate) bool {
 	if !d.Valid && !other.Valid {
 		return true // both null means equal
 	}
@@ -104,4 +104,3 @@ func (d *NullDate) Equal(other NullDate) bool {
 	}
 	return d.Date.Equal(other.Date)
 }
-

--- a/nulltime.go
+++ b/nulltime.go
@@ -46,7 +46,7 @@ func (t *NullTime) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON marshals a NullTime into JSON format. The date is formatted
 // in RFC 3339 full-date format -- that is, yyyy-mm-dd.
-func (t *NullTime) MarshalJSON() ([]byte, error) {
+func (t NullTime) MarshalJSON() ([]byte, error) {
 	var ds string
 	if t.Valid {
 		ti := time.Time(t.Time)
@@ -60,7 +60,7 @@ func (t *NullTime) MarshalJSON() ([]byte, error) {
 // Implement Stringer
 
 // String returns the value of the NullTime in ISO-8601 / RFC 3339 format yyyy-mm-dd.
-func (t *NullTime) String() string {
+func (t NullTime) String() string {
 	if t.Valid {
 		return t.Time.String()
 	}
@@ -70,7 +70,7 @@ func (t *NullTime) String() string {
 // Implement Valuer
 
 // Value implements the database/sql Valuer interface.
-func (t *NullTime) Value() (driver.Value, error) {
+func (t NullTime) Value() (driver.Value, error) {
 	if t.Valid {
 		return time.Time(t.Time), nil
 	}
@@ -95,7 +95,7 @@ func (t *NullTime) Scan(value interface{}) error {
 }
 
 // Equal returns true if the two dates are equal.
-func (t *NullTime) Equal(other NullTime) bool {
+func (t NullTime) Equal(other NullTime) bool {
 	if !t.Valid && !other.Valid {
 		return true // both null means equal
 	}

--- a/time.go
+++ b/time.go
@@ -32,8 +32,8 @@ func (ti *Time) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON marshals a Time into JSON format. The date is formatted
 // in RFC 3339 format -- that is, hh:mm:ss in 24 hour clock
-func (ti *Time) MarshalJSON() ([]byte, error) {
-	t := time.Time(*ti)
+func (ti Time) MarshalJSON() ([]byte, error) {
+	t := time.Time(ti)
 	ds := "\"" + t.Format(timeFormat) + "\""
 	return []byte(ds), nil
 }
@@ -41,15 +41,15 @@ func (ti *Time) MarshalJSON() ([]byte, error) {
 // Implement Stringer
 
 // String returns the value of the Time in hh:mm:ss format.
-func (ti *Time) String() string {
-	return time.Time(*ti).Format(timeFormat)
+func (ti Time) String() string {
+	return time.Time(ti).Format(timeFormat)
 }
 
 // Implement Valuer
 
 // Value implements the database/sql Valuer interface.
-func (ti *Time) Value() (driver.Value, error) {
-	return time.Time(*ti), nil
+func (ti Time) Value() (driver.Value, error) {
+	return time.Time(ti), nil
 }
 
 // Implement Scanner


### PR DESCRIPTION
Methods like `String`, `MarshalJSON`, and `Equal` should not take pointers in
their method receivers. This prevents JSON marshalling and
stringificantion from working correctly on variables that are not
pointers, for example.